### PR TITLE
Add Bio for Luke Neilson

### DIFF
--- a/content/team/luke-neilson.md
+++ b/content/team/luke-neilson.md
@@ -2,8 +2,8 @@
 ## Research Assistant: [Google Scholar](https://scholar.google.com/citations?user=)
 
 
-Luke is a high-school student at Uintah High School that works part-time as a  (background, skills before joining, what drove him to join).
+Luke is a student at Uintah High School that works part-time as a high school student researcher at Bingham Research Center. Luke has a good amount of experience working with programming languages like HTML, CSS, and JavaScript. He is good at math and has taken an AP Precalculus class, scoring fairly high on the AP test. He is planning on pursuing a career in website or software development which has drawn him to join the Bingham Research Center, specifically on the programming side of the center.
 
-Currently, I'm developing (research in plain language, one recent project adding to operations/applications, one current project (main focus), one early stage looking to future applications.)
+Currently, Luke is developing this site, the JRL academic site. He is also contributing bits and pieces to basinwx.com, mostly focusing on the water weather page of the site.
 
-Outside the lab, Luke (hobbies, interests, family life, etc.)
+Outside the lab, Luke also really likes music. He sings, plays the piano and percussion, and composes some songs of his own. He has really enjoyed coding on his own and has made some games on scratch.mit.edu. When he's not making music or coding, he likes making up stories, usually about dimension travelling superheroes with the strangest backstories.


### PR DESCRIPTION
This change replaces the placeholder for Luke Neilson's bio with an actual bio on the team page of the website.