### PR TITLE
Add relevant details to Quinten Baldwin's bio

### DIFF
--- a/content/team/quinten-baldwin.md
+++ b/content/team/quinten-baldwin.md
@@ -2,8 +2,8 @@
 ## Research Assistant: [Google Scholar](https://scholar.google.com/citations?user=)
 
 
-Quinten Baldwin is a student at Uintah High School who works part time as a Student Research Assistant at Bingham Research Center. Quinten works on code regarding the Basinwx website and also does some work in the lab. He does programming in languages like Python, JavaScript, and CSS/HTML, and also has some experience in other programming languages like C#, Lua, and more.
+I am a student at Uintah High School who works part time as a Student Research Assistant at Bingham Research Center. I work on code regarding the Basinwx website and also do some work in the lab. I do programming in languages like Python, JavaScript, and CSS/HTML, and also have some experience in other programming languages like C#, Lua, and more. I am generally interested in anything tech or programming.
 
-Currently, Quinten is working on the general development of the Basinwx website, but also on a new, yet to be implemented, page and feature. He also helps in the lab doing things like measuring perm tubes.
+Currently, I am working on the general development of the Basinwx website, but also on a new, yet to be implemented, page and feature. I also help in the lab doing things like measuring perm tubes.
 
-Outside of work, Quinten also works on his own personal projects involving programming and other hobbies. He works on other projects with his friends as well as simply hanging out. He enjoys spending time with his family.
+Outside of work, I also work on my own personal projects involving programming and other hobbies. I enjoy building games and just generally learning about computers. Outside of computer related things, I also like working with my friends on all our shared projects, as well as working on my own personal hobbies by myself, like doodling, writing, or just thinking. I enjoy spending time with my family.


### PR DESCRIPTION
This PR adds details to Quinten Baldwin's bio that makes it more complete, although it is still fluid and can be changed if needed. The new information was mixed in with the old from info that Quinten sent to John Lawson.