### PR TITLE
Add paragraph on AI use to Braxton Wilcken-Pond's bio

### DIFF
--- a/content/team/braxton-wilcken-pond.md
+++ b/content/team/braxton-wilcken-pond.md
@@ -4,4 +4,6 @@
 
 My name is Braxton Wilcken‑Pond, and I am a High School Research Assistant at Utah State University’s Uintah Basin campus. Throughout my high school career, I have earned multiple certificates in entrepreneurship, marketing, engineering, electronics, accounting, and digital design. I have consistently maintained a 4.0 GPA and am a member of the National Honor Society with three and a half consecutive years of active membership. I strive to embody hard work, leadership, resilience, integrity, authenticity, and discipline in everything I do.
 
+At BRC, my work focuses primarily on the physical aspects of our projects, along with developing electrical schematics and standard operating procedures. Throughout these tasks, I’ve used AI as a research tool to deepen my understanding of the concepts involved. This has included everything from reviewing equations to examining reference SOPs. Using it in this way has not only expanded my knowledge across a range of topics but has also significantly improved my efficiency. For me, AI supports the work that I do, it doesn’t replace it.
+
 Outside of work, I enjoy spending time with family and friends, playing sports or video games, designing solutions to real‑world problems, learning new skills, and experimenting with new ideas.


### PR DESCRIPTION
This PR adds a paragraph that explains how Braxton Wilcken-Pond uses AI in his tasks as a research assistant at BRC. This is a good addition to the information that was already in the bio.